### PR TITLE
change nest.rb temperature call from temperature to current_temp

### DIFF
--- a/jobs/nest.rb
+++ b/jobs/nest.rb
@@ -8,7 +8,7 @@ use_metric_system = false
 SCHEDULER.every '1m', :first_in => 0 do |job|
 	nest = NestThermostat::Nest.new({email: nest_user,password: nest_password})
 	first_nest = nest.status["shared"][nest.device_id]
-	temp = nest.temperature.to_i; 
+	temp = nest.current_temp.to_i; 
 	if (use_metric_system)
 		temp = f_to_c(temp)
 	end


### PR DESCRIPTION
current_temp seems to be the proper method to call to get the current nest temperature:

[4] pry(main)> nest = NestThermostat::Nest.new({email: nest_user,password: nest_password})
[5] pry(main)> nest.temp
=> 68.0
[7] pry(main)> nest.temperature
=> 68.0
[8] pry(main)> nest.current_temp
=> 70.376
